### PR TITLE
upgrade csv-spectrum to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "bl": "^1.0.0",
-    "csv-spectrum": "^0.2.0",
+    "csv-spectrum": "^0.3.0",
     "standard": "^5.2.1",
     "stream-array": "^1.1.1",
     "tape": "^4.2.0"


### PR DESCRIPTION
to catch failing test brought up by https://github.com/holodex/csv-formatter/pull/1.

ref: https://github.com/maxogden/csv-spectrum/issues/13
