### PR TITLE
Fix shorthand headers options

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,13 +13,17 @@ function csvFormatter (options) {
 
   var headerWritten = false
 
-  return through.obj(function (row, enc, cb) {
+  var stream = through.obj(function (row, enc, cb) {
     if (!headerWritten) {
       this.push(formatHeaderRow(options, row))
       headerWritten = true
     }
     cb(null, formatBodyRow(options, row))
   })
+
+  stream.options = options
+
+  return stream
 }
 
 function getOptions (options) {

--- a/index.js
+++ b/index.js
@@ -23,14 +23,14 @@ function csvFormatter (options) {
 }
 
 function getOptions (options) {
+  if (Array.isArray(options)) {
+    options = { headers: options }
+  }
+
   options = defined(options, {})
 
   options.separator = defined(options.separator, ',')
   options.newline = defined(options.newline, '\n')
-
-  if (Array.isArray(options)) {
-    options = { headers: options }
-  }
 
   return options
 }

--- a/test/index.js
+++ b/test/index.js
@@ -48,3 +48,61 @@ test('csv-spectrum', function (t) {
     })
   })
 })
+
+test('options', function (t) {
+  t.test('undefined', function (t) {
+    var csv = csvFormatter()
+    var expected = {
+      separator: ',',
+      newline: '\n'
+    }
+
+    t.same(csv.options, expected, 'applies default options')
+    t.end()
+  })
+
+  t.test('object', function (t) {
+    t.test('separator', function (t) {
+      var csv = csvFormatter({
+        separator: ';'
+      })
+
+      t.equal(csv.options.separator, ';', 'applies separator option')
+      t.end()
+    })
+
+    t.test('newline', function (t) {
+      var csv = csvFormatter({
+        newline: '\r\n'
+      })
+
+      t.equal(csv.options.newline, '\r\n', 'applies newline option')
+      t.end()
+    })
+
+    t.test('headers', function (t) {
+      var csv = csvFormatter({
+        headers: ['index', 'message']
+      })
+
+      t.same(csv.options.headers, ['index', 'message'], 'applies headers option')
+      t.end()
+    })
+
+    t.end()
+  })
+
+  t.test('array', function (t) {
+    var csv = csvFormatter(['index', 'message'])
+    var expected = {
+      separator: ',',
+      newline: '\n',
+      headers: ['index', 'message']
+    }
+
+    t.same(csv.options, expected, 'applies default & headers options')
+    t.end()
+  })
+
+  t.end()
+})


### PR DESCRIPTION
Currently `options` are overwritten after the defaults have been applied, which results in `undefined` as `newline` property.

The stream that gets returned now exposes an `options` property for easy testability.

Added test for the instance options, do you prefer `t.end()` or `t.plan(1)`?
